### PR TITLE
basic initialization of rppal uart

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,18 +5,20 @@ use std::error::Error;
 use std::thread;
 use std::time::Duration;
 
-use rppal::uart::{
-    Parity,
-    Uart,
-    Result,
-};
-use rppal::system::DeviceInfo;
-
 // Gpio uses BCM pin numbering. BCM GPIO 23 is tied to physical pin 16.
 const GPIO_UART_TX: u8 = 14;
 
 #[cfg(test)]
 mod tests {
+    use rppal::{
+        uart::{
+            Parity,
+            Uart,
+            Result,
+        },
+        system::DeviceInfo,
+    };
+ 
     #[test]
     fn it_works() {
         assert_eq!(2 + 2, 4);
@@ -25,16 +27,8 @@ mod tests {
     #[test]
     fn lights() -> () {
         // println!("Blinking an LED on a {}.", super::DeviceInfo::new().unwrap().model());
-        let uart: super::Result<super::Uart> = super::Uart::new(115_200, super::Parity::None, 8u8, 1u8);
-        
-        match uart {
-            Ok(_) => println!("uart init work"),
-            Err(err) =>{
-                println!("{:?}", err);
-                panic!();
-            },
+        let uart: Uart = Uart::new(115_200, Parity::None, 8u8, 1u8).unwrap();
 
-        };
         // Blink the LED by setting the pin's logic level high for 500 ms.
         // uart.set_high();
         // thread::sleep(Duration::from_millis(500));


### PR DESCRIPTION
as the title mentions.
moved the "use"-statements into the test module to avoid having to write super in front of all uses.